### PR TITLE
fix the bind_host configure

### DIFF
--- a/manifests/api.pp
+++ b/manifests/api.pp
@@ -44,7 +44,7 @@ class cinder::api (
   }
 
   cinder_config {
-    'DEFAULT/bind_host': value => $bind_host
+    'DEFAULT/osapi_volume_listen': value => $bind_host
   }
 
   if $keystone_enabled {


### PR DESCRIPTION
In the cinder-api, it use `osapi_volume_listen` to configure the listening address
