### PR TITLE
cinder backup correct module name

### DIFF
--- a/manifests/backup/ceph.pp
+++ b/manifests/backup/ceph.pp
@@ -54,7 +54,7 @@
 #
 
 class cinder::backup::ceph (
-  $backup_driver            = 'cinder.backup.driver.ceph',
+  $backup_driver            = 'cinder.backup.drivers.ceph',
   $backup_ceph_conf         = '/etc/ceph/ceph.conf',
   $backup_ceph_user         = 'cinder',
   $backup_ceph_chunk_size   = '134217728',


### PR DESCRIPTION
This commit corrects the default ceph backup driver name to cinder.backup.drivers.ceph as cinder.backup.driver.ceph could not be found, obviously.
