### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ class { 'cinder::backends':
 }
 ```
 
-Note: that the name passed to any backend resource must be unique accross all backends otherwise a duplicate resource will be defined.
+Note: that the name passed to any backend resource must be unique across all backends otherwise a duplicate resource will be defined.
 
 ** Using type and type_set **
 


### PR DESCRIPTION
@openstack, I've corrected a typographical error in the documentation of the [puppet-cinder](https://github.com/openstack/puppet-cinder) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.