### PR TITLE
Make EMC VNX backend class compatible with FC driver

### DIFF
--- a/manifests/backend/emc_vnx.pp
+++ b/manifests/backend/emc_vnx.pp
@@ -11,7 +11,7 @@
 #   Defaults to: $name
 #
 # [*iscsi_ip_address*]
-#   (Required) The IP address that the iSCSI daemon is listening on
+#   The IP address that the iSCSI daemon is listening on
 #
 # [*san_ip*]
 #   (required) IP address of SAN controller.
@@ -73,10 +73,10 @@
 #   Defaults to false.
 #
 define cinder::backend::emc_vnx (
-  $iscsi_ip_address,
   $san_ip,
   $san_password,
   $storage_vnx_pool_name,
+  $iscsi_ip_address              = $::os_service_default,
   $default_timeout               = '10',
   $max_luns_per_storage_group    = '256',
   $package_ensure                = 'present',
@@ -93,6 +93,11 @@ define cinder::backend::emc_vnx (
 
   include ::cinder::deps
   include ::cinder::params
+
+  if $volume_driver == 'cinder.volume.drivers.emc.emc_cli_iscsi.EMCCLIISCSIDriver' and
+    $iscsi_ip_address == $::os_service_default {
+    fail('iscsi_ip_address needs to be set when using the cinder.volume.drivers.emc.emc_cli_iscsi.EMCCLIISCSIDriver volume_driver')
+  }
 
   cinder_config {
     "${name}/default_timeout":                 value => $default_timeout;

--- a/spec/defines/cinder_backend_emc_vnx_spec.rb
+++ b/spec/defines/cinder_backend_emc_vnx_spec.rb
@@ -21,7 +21,20 @@ describe 'cinder::backend::emc_vnx' do
     req_params
   end
 
-  describe 'emc vnx volume driver' do
+  describe 'emc vnx volume driver with only required parameters' do
+    before :each do
+      params.merge!({
+        :iscsi_ip_address      => '<SERVICE DEFAULT>'
+      })
+    end
+    it 'configure with required/default parameters' do
+      expect {
+        is_expected.to compile
+      }.to raise_error(/iscsi_ip_address needs to be set when using the cinder.volume.drivers.emc.emc_cli_iscsi.EMCCLIISCSIDriver volume_driver/)
+    end
+  end
+
+  describe 'emc vnx volume driver with iscsi configuration' do
     it 'configure emc vnx volume driver' do
       is_expected.to contain_cinder_config('emc/volume_driver').with_value('cinder.volume.drivers.emc.emc_cli_iscsi.EMCCLIISCSIDriver')
       is_expected.to contain_cinder_config('emc/san_ip').with_value('127.0.0.2')
@@ -33,7 +46,28 @@ describe 'cinder::backend::emc_vnx' do
       is_expected.to contain_cinder_config('emc/storage_vnx_authentication_type').with_value('<SERVICE DEFAULT>')
       is_expected.to contain_cinder_config('emc/storage_vnx_security_file_dir').with_value('<SERVICE DEFAULT>')
       is_expected.to contain_cinder_config('emc/naviseccli_path').with_value('<SERVICE DEFAULT>')
+    end
+  end
 
+  describe 'emc vnx volume driver with fc configuration' do
+    before :each do
+      params.merge!({
+       :iscsi_ip_address      => '<SERVICE DEFAULT>',
+       :volume_driver         => 'cinder.volume.drivers.emc.emc_cli_fc.EMCCLIFCDriver',
+      })
+    end
+
+    it 'configure emc vnx volume driver' do
+      is_expected.to contain_cinder_config('emc/volume_driver').with_value('cinder.volume.drivers.emc.emc_cli_fc.EMCCLIFCDriver')
+      is_expected.to contain_cinder_config('emc/san_ip').with_value('127.0.0.2')
+      is_expected.to contain_cinder_config('emc/san_login').with_value('emc')
+      is_expected.to contain_cinder_config('emc/san_password').with_value('password')
+      is_expected.to contain_cinder_config('emc/iscsi_ip_address').with_value('<SERVICE DEFAULT>')
+      is_expected.to contain_cinder_config('emc/storage_vnx_pool_name').with_value('emc-storage-pool')
+      is_expected.to contain_cinder_config('emc/initiator_auto_registration').with_value('<SERVICE DEFAULT>')
+      is_expected.to contain_cinder_config('emc/storage_vnx_authentication_type').with_value('<SERVICE DEFAULT>')
+      is_expected.to contain_cinder_config('emc/storage_vnx_security_file_dir').with_value('<SERVICE DEFAULT>')
+      is_expected.to contain_cinder_config('emc/naviseccli_path').with_value('<SERVICE DEFAULT>')
     end
   end
 


### PR DESCRIPTION
This is achieved by removing the requirement of iscsi_ip_address, and only throw
an error message if missing and using the
'cinder.volume.drivers.emc.emc_cli_iscsi.EMCCLIISCSIDriver' volume_driver.